### PR TITLE
Better detect chart timeframe menu roots and try multiple candidates when selecting 4H

### DIFF
--- a/update-watchlist.js
+++ b/update-watchlist.js
@@ -1114,13 +1114,15 @@ async function openChartTimeframeMenu(page) {
   return false;
 }
 
-async function findTimeframeMenuRoot(page) {
+async function findTimeframeMenuRoots(page) {
   const selectors = [
     '[role="menu"]',
     '[role="listbox"]',
     'div[data-name="menu-inner"]',
     'div[class*="menu"]',
   ];
+
+  const scored = [];
 
   for (const sel of selectors) {
     const loc = page.locator(sel);
@@ -1132,16 +1134,39 @@ async function findTimeframeMenuRoot(page) {
 
       const text = normalizeTvText(await root.textContent().catch(() => ""));
       const has240 = (await root.locator('[data-value="240"]').count().catch(() => 0)) > 0;
-      const looksLikeTfMenu =
-        has240 ||
-        /seconds|minutes|hours|days|weeks|months|秒|分|時間|日|週|月/.test(text);
+      const rowCount = await root
+        .locator('[data-role="menuitem"], [role="row"], [role="option"]')
+        .count()
+        .catch(() => 0);
 
-      if (looksLikeTfMenu) return root;
+      const hasTfWords = /seconds|minutes|hours|days|weeks|months|秒|分|時間|日|週|月/.test(text);
+      const has4hText = /\b4\s*h(?:ours?)?\b|4\s*時間/.test(text);
+      const hasAddCustom = /add\s+custom\s+interval|カスタム/.test(text);
+      const hasOnlyFavoriteHints = /add\s+to\s+favorites/.test(text) && !hasTfWords && !has4hText;
+
+      let score = 0;
+      if (has240) score += 8;
+      if (has4hText) score += 6;
+      if (hasTfWords) score += 4;
+      if (hasAddCustom) score += 3;
+      score += Math.min(rowCount, 8);
+      if (hasOnlyFavoriteHints) score -= 6;
+
+      if (score > 0) {
+        scored.push({ root, score });
+      }
     }
   }
 
-  return null;
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((x) => x.root);
 }
+
+async function findTimeframeMenuRoot(page) {
+  const roots = await findTimeframeMenuRoots(page);
+  return roots.length ? roots[0] : null;
+}
+
 
 async function expandHoursSectionIfNeeded(page, menuRoot) {
   const headers = [
@@ -1271,13 +1296,18 @@ async function ensureChartTimeframe(page, targetLabel = "4 時間") {
 
   await logChartTimeframeMenuState(page, 'chart-timeframe-opened');
 
-  const root = await findTimeframeMenuRoot(page);
-  if (!root) {
+  const roots = await findTimeframeMenuRoots(page);
+  if (!roots.length) {
     await safeScreenshot(page, 'chart_timeframe_menu_not_found');
     throw new Error("チャート時間足メニューが見つかりませんでした");
   }
 
-  const ok = await select4hFromMenu(page, root);
+  let ok = false;
+  for (const root of roots) {
+    ok = await select4hFromMenu(page, root);
+    if (ok) break;
+  }
+
   if (!ok) {
     await safeScreenshot(page, 'chart_4h_not_found');
     throw new Error(`チャート時間足 "${targetLabel}" が見つかりませんでした`);


### PR DESCRIPTION
### Motivation
- The existing single-root detection for the chart timeframe menu was brittle when multiple menu-like containers exist, causing intermittent failures to select the 4H timeframe. 
- Improve robustness by scoring and preferring likely timeframe menus and by attempting selection on multiple candidates. 

### Description
- Add `findTimeframeMenuRoots` which scans candidate selectors, computes a heuristic `score` using presence of `240`/4h hints, timeframe words, custom-interval hints, and row counts, and returns roots sorted by score. 
- Keep `findTimeframeMenuRoot` as a thin wrapper that returns the highest-scoring root, and update `ensureChartTimeframe` to iterate over all returned roots and call `select4hFromMenu` until one succeeds. 
- Penalize misleading menus (e.g. only favorite hints) and favor roots with more menu rows to reduce false positives. 

### Testing
- Ran the project automated test suite with `npm test` and linters where applicable, and the suite completed successfully. 
- Performed a smoke/integration run of `update-watchlist.js` (headless) exercising the chart timeframe selection flow to verify the script can find and select the 4H option, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7577d9c9c8322b0c0c59d977ab702)