### PR TITLE
fix: ウォッチリスト削除の不具合修正（サイドバー誤マッチ・SyntaxError）

### DIFF
--- a/update-watchlist.js
+++ b/update-watchlist.js
@@ -768,7 +768,6 @@ async function deleteManagedWatchlistsByPrefix(page, prefix) {
 
   throw new Error(`削除ループが上限に達しました: ${prefix}`);
 }
-}
 
 async function confirmTradingViewDialog(page) {
   console.log("[dialog] 確認ダイアログを待機中...");


### PR DESCRIPTION
## 修正内容

### 問題
- ウォッチリスト削除が機能しない（完走するが削除されない）
- `SyntaxError: Unexpected token '}'` でクラッシュ

### 根本原因
1. 現在アクティブなウォッチリスト名がサイドバーにも `div[data-role="list-item"][data-title]` として存在するため、削除ダイアログ内の行より先にマッチしてしまい、ホバーしても削除ボタンが出なかった
2. 前回のリファクタリングで余分な `}` が混入していた

### 修正
- ホバー後に削除ボタンが見つからない場合は次の行を試すよう変更（サイドバー要素をスキップ）
- `scrollIntoViewIfNeeded` + `hover({ force: true })` で確実にホバー
- 余分な閉じ括弧を削除してSyntaxErrorを解消