### PR TITLE
Remove fullPage option from screenshot capture

### DIFF
--- a/update-watchlist.js
+++ b/update-watchlist.js
@@ -93,7 +93,7 @@ async function safeScreenshot(page, label) {
   try {
     ensureDir(WORKDIR);
     const p = path.join(WORKDIR, `screenshot_${Date.now()}_${label}.png`);
-    await page.screenshot({ path: p, fullPage: true });
+    await page.screenshot({ path: p });
     console.log("Saved screenshot:", p);
   } catch (e) {
     console.log("Screenshot failed:", e?.message || e);


### PR DESCRIPTION
## Summary
Removed the `fullPage: true` option from the screenshot method call in the `safeScreenshot` function to capture only the visible viewport instead of the entire page.

## Changes
- Removed `fullPage: true` parameter from `page.screenshot()` call, allowing screenshots to capture only the currently visible portion of the page rather than scrolling through and capturing the entire page height

## Details
This change modifies the screenshot behavior to be more performant and focused on the visible viewport. Full-page screenshots can be resource-intensive and time-consuming, especially for long pages. By removing this option, the function will now capture only what's currently visible on screen, which is typically more useful for debugging and monitoring purposes.

https://claude.ai/code/session_01YJa8KJzdkiANf52igUiz9P