### PR TITLE
[auto-fix] ワークフロー失敗: main

### DIFF
--- a/update-watchlist.js
+++ b/update-watchlist.js
@@ -93,7 +93,7 @@ async function safeScreenshot(page, label) {
   try {
     ensureDir(WORKDIR);
     const p = path.join(WORKDIR, `screenshot_${Date.now()}_${label}.png`);
-    await page.screenshot({ path: p, fullPage: true });
+    await page.screenshot({ path: p });
     console.log("Saved screenshot:", p);
   } catch (e) {
     console.log("Screenshot failed:", e?.message || e);


### PR DESCRIPTION
## Summary\n- `safeScreenshot` の `fullPage: true` を削除し、ビューポート内のみのスクリーンショットに変更\n- `fullPage: true` による巨大PNGがAnthropicAPIの画像サイズ制限を超え、Claude Code Routinesで `\"Could not process image\"` エラーが発生していた\n\nCloses #21