### PR TITLE
fix: remove fullPage from screenshots to prevent API image size error

### DIFF
--- a/update-watchlist.js
+++ b/update-watchlist.js
@@ -94,7 +94,7 @@ async function safeScreenshot(page, label) {
   try {
     ensureDir(WORKDIR);
     const p = path.join(WORKDIR, `screenshot_${Date.now()}_${label}.png`);
-    await page.screenshot({ path: p, fullPage: true });
+    await page.screenshot({ path: p });
     console.log("Saved screenshot:", p);
   } catch (e) {
     console.log("Screenshot failed:", e?.message || e);


### PR DESCRIPTION
fullPage: true produces oversized PNGs that exceed the Anthropic API's image processing limit, causing "Could not process image" 400 errors in Claude Code Routines auto-fix flows.

https://claude.ai/code/session_01YJa8KJzdkiANf52igUiz9P